### PR TITLE
Add big endian support for mksquashfs.

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -344,7 +344,7 @@ all: sasquatch
 
 # CJH: Added LZMA_EXTRA_OBJS
 mksquashfs: $(MKSQUASHFS_OBJS)
-	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LZMA_EXTRA_OBJS) $(MKSQUASHFS_OBJS) $(LIBS) -o $@
+	$(CXX) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LZMA_EXTRA_OBJS) $(MKSQUASHFS_OBJS) $(LIBS) -o $@
 	ln -sf mksquashfs sqfstar
 
 mksquashfs.o: Makefile mksquashfs.c squashfs_fs.h squashfs_swap.h mksquashfs.h \

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -78,6 +78,7 @@ int delete = FALSE;
 int quiet = FALSE;
 int fd;
 struct squashfs_super_block sBlk;
+struct override_table override = { 0 };
 
 /* filesystem flags for building */
 int comp_opts = FALSE;


### PR DESCRIPTION
This commit fix a bug that happened when building mksquashfs due to the lack of 'override' definition.

This allows users to build mksquashfs in big-endian mode to craft v4 big-endian filesystems.

I needed it when crafting integration test cases for unblob :)